### PR TITLE
python 3 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,10 @@ pulsar_filterbank_osmo.grc: pulsar_filterbank.grc
 #
 pulsar_filterbank_uhd.py: pulsar_filterbank_uhd.grc
 
-	-grcc -d . pulsar_filterbank_uhd.grc
+	-grcc pulsar_filterbank_uhd.grc
 
 pulsar_filterbank_osmo.py: pulsar_filterbank_osmo.grc
-	-grcc -d . pulsar_filterbank_osmo.grc
+	-grcc pulsar_filterbank_osmo.grc
 
 #
 # Now edit the resulting .py code to include appropriate time-sync primitives

--- a/fb_helper.py
+++ b/fb_helper.py
@@ -470,8 +470,8 @@ def update_header(pacer,runtime,smpsize):
                 seconds = first_tag
             else:
                 seconds = time.time()
-            print "No rx_time tag, start time will be approximate."
-        
+            print("No rx_time tag, start time will be approximate.")
+
         #
         # Turn real seconds into MJD
         #

--- a/fb_helper.py
+++ b/fb_helper.py
@@ -107,11 +107,17 @@ def convert_sigproct(v):
     timestr="%02d%02d%02d.0" % (hours, minutes, seconds)
     return(float(timestr))
 
+
+def tobytes(s):
+    """converts specified parameter to bytes. Python 3 is much more picky regarding
+       differences between strings and bytes. This function is used in build_header_info()"""
+    return bytes(str(s),'utf-8')
+
 #
 # This will cause a header block to be prepended to the output file
 #
 # Thanks to Guillermo Gancio (ganciogm@gmail.com) for the inspiration
-#   and much of the code
+# and much of the code. Adjusted to python 3 by Tomek Mrugalski.
 #
 def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fbsize,rx_time,smpsize):
     global smpwidth
@@ -127,7 +133,6 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     header_args["bw"] = bw
     header_args["fbrate"] = fbrate
     header_args["fbsize"] = fbsize
-
 
     #
     # Time for one sample, in sec
@@ -161,29 +166,31 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     sub_bands=fbsize
 
     #
-    # Determine MJD from file timestamp
+    # Determine MJD from file timestamp. Open the output file as binary.
     #
     if (rx_time == None):
-        fp = open(outfile, "w")
+        fp = open(outfile, "wb")
         t_start = (os.path.getmtime(outfile) / 86400) + 40587
     else:
-        fp = open(outfile, "w")
+        fp = open(outfile, "wb")
         t_start = rx_time
 
     #
     # The rest here is mostly due to Guillermo Gancio ganciogm@gmail.com
     #
-    stx="HEADER_START"
-    etx="HEADER_END"
+    stx=tobytes("HEADER_START")
+    etx=tobytes("HEADER_END")
     fp.write(struct.pack('i', len(stx))+stx)
     fp.flush()
+
     #--
-    aux="rawdatafile"
+    aux=tobytes("rawdatafile")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
-    fp.write(struct.pack('i', len(outfile))+outfile)
+    fp.write(struct.pack('i', len(outfile))+tobytes(outfile))
+
     #--
-    aux="src_raj"
+    aux=tobytes("src_raj")
     aux=struct.pack('i', len(aux))+aux
     source_ra = convert_sigproct(source_ra)
     fp.write(aux)
@@ -192,96 +199,106 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     fp.flush()
 
     #--
-    aux="src_dej"
+    aux=tobytes("src_dej")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     source_dec= convert_sigproct(source_dec)
     aux=struct.pack('d', source_dec)
     fp.write(aux)
     #--
-    aux="az_start"
+
+    aux=tobytes("az_start")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', 0.0)
     fp.write(aux)
     #--
-    aux="za_start"
+    aux=tobytes("za_start")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', 0.0)
     fp.write(aux)
     #--
-    aux="tstart"
+    aux=tobytes("tstart")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', float(t_start))
     fp.write(aux)
     #--
-    aux="foff"
+    aux=tobytes("foff")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', f_off)
     fp.write(aux)
     #--
-    aux="fch1"
+    aux=tobytes("fch1")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', high_freq)
     fp.write(aux)
     #--
-    aux="nchans"
+    aux=tobytes("nchans")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', sub_bands)
     fp.write(aux)
     #--
-    aux="data_type"
+    aux=tobytes("data_type")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
     #--
-    aux="ibeam"
+
+
+    aux=tobytes("ibeam")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
     #--
-    aux="nbits"
+    aux=tobytes("nbits")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', smpsize*8)
     fp.write(aux)
     #--
-    aux="tsamp"
+
+
+    aux=tobytes("tsamp")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', tsamp)
     fp.write(aux)
     #--
-    aux="nbeams"
+    aux=tobytes("nbeams")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
+
+
     #--
-    aux="nifs"
+    aux=tobytes("nifs")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
+
     #--
-    aux="source_name"
+    aux=tobytes("source_name")
     fp.write(struct.pack('i', len(aux))+aux)
-    fp.write(struct.pack('i', len(source_name))+source_name)
+    fp.write(struct.pack('i', len(source_name)) + tobytes(source_name))
+
+
     #--
-    aux="machine_id"
+    aux=tobytes("machine_id")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 20)
     fp.write(aux)
     #--
-    aux="telescope_id"
+    aux=tobytes("telescope_id")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 20)

--- a/fb_helper.py
+++ b/fb_helper.py
@@ -612,8 +612,10 @@ def dynamic_mask(fft,smask,thresh):
     #
     # Determine trim range
     #
+    # (Python 3 update: make sure the ff is integer. Arrays can only be
+    # indexed by integers)
     lf = len(fft)
-    ff = lf/10
+    ff = int(lf/10)
     if (ff == 0):
         ff = 1
 

--- a/fb_helper.py
+++ b/fb_helper.py
@@ -833,7 +833,8 @@ def analyser(fft,nchan):
     global spikes
     global lastchan
 
-    nfft = fft[0:len(fft)/2]
+    # python 3 fix: indices must be integers
+    nfft = fft[0:int(len(fft)/2)]
     if channels == None:
         channels = [numpy.array([0.0]*len(nfft))]*nchan
         chcnts = [0.0]*nchan

--- a/fb_helper.py
+++ b/fb_helper.py
@@ -37,30 +37,30 @@ def dm_to_smear(freq,bw,dm):
 #
 # Convert DM to a reasonable number of FFT bins, given
 #  DM, center-frequency, bandwidth, and pw50
-# 
+#
 def dm_to_bins(dm,freq,bw,pw50):
-    
+
     #
     # Convert pw50 to milliseconds (sigh)
     #
     p50ms = pw50 * 1000.0
-    
+
     Dt = dm_to_smear(freq,bw,dm)
-    
+
     #
     # So that there's only 25% (of W50) residual smearing in each channel of the FB
     #
     required_bins = Dt/(p50ms/4.0)
-    
+
     #
     # We do a bit of base2 math to make this a nice FFT size
     #
     bins = math.log(required_bins)/math.log(2.0)
     if (abs(bins-int(bins)) > 0.2):
         bins += 1
-    
+
     bins = int(bins)
-    
+
     #
     # No sense making the filterbank too small
     # Set bins so that minimum is 4 channels
@@ -74,10 +74,10 @@ def dm_to_bins(dm,freq,bw,pw50):
 #
 def write_header(fn, freq, bw, fbsize, fbrate, smpsize):
     global smpwidth
-    
+
     if (smpwidth == 0):
         smpwidth = smpsize
-        
+
     f = open(fn, "w")
     ltp = time.gmtime(time.time())
     f.write("frequency=%.5f\n" % freq)
@@ -90,7 +90,7 @@ def write_header(fn, freq, bw, fbsize, fbrate, smpsize):
         ltp.tm_min, ltp.tm_sec))
     f.write("Output sample size %d bytes\n" % smpsize)
     f.write("Expected disk write rate: %6.2f mbyte/sec\n" % ((fbsize*fbrate*smpsize)/1.0e6))
-    
+
 
 
 header_args = {}
@@ -106,7 +106,7 @@ def convert_sigproct(v):
     seconds = itime - (hours*3600) - (minutes*60)
     timestr="%02d%02d%02d.0" % (hours, minutes, seconds)
     return(float(timestr))
-  
+
 #
 # This will cause a header block to be prepended to the output file
 #
@@ -115,7 +115,7 @@ def convert_sigproct(v):
 #
 def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fbsize,rx_time,smpsize):
     global smpwidth
-    
+
     if (smpwidth == 0):
         smpwidth = smpsize
 
@@ -133,33 +133,33 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     # Time for one sample, in sec
     #
     tsamp=1.0/fbrate
-    
+
     #
     # Frequency offset between channels, in MHz
     #
     f_off=bw/fbsize
     f_off /= 1.0e6
     f_off *= -1
-    
+
     #
     # Highest frequency represented in FB, in MHz
     #
     high_freq = freq+(bw/2.0)
     high_freq  /= 1.0e6
     high_freq -= (f_off/2.0)
-    
+
     #
     # Lowest
     #
     low_freq = freq-(bw/2.0)
     low_freq /= 1.0e6
     low_freq += (f_off/2.0)
-    
+
     #
     # Number of subbands
     #
     sub_bands=fbsize
-    
+
     #
     # Determine MJD from file timestamp
     #
@@ -169,7 +169,7 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     else:
         fp = open(outfile, "w")
         t_start = rx_time
- 
+
     #
     # The rest here is mostly due to Guillermo Gancio ganciogm@gmail.com
     #
@@ -315,13 +315,13 @@ def log_fft(freq,bw,prefix,fft):
     global smooth_fft
     global fft_cnt
     global last_smooth
-    
+
     #
     # Degenerate FFT length--sometimes on startup
     #
     if (len(fft) < 2):
         return
-    
+
     #
     # Provide "smooth" FFT for get_correction
     #  function
@@ -337,28 +337,28 @@ def log_fft(freq,bw,prefix,fft):
     #
     if (time.time() < next_fft):
         return
-    
+
     #
     # Schedule our next one
     #
     next_fft = time.time() + 10.0
- 
+
     #
     # Get current time, break out into "struct tm" style time fields
     #
     ltp = time.gmtime(time.time())
-    
+
     #
     # Constract filename from parts
     #
     date = "%04d%02d%02d%02d" % (ltp.tm_year, ltp.tm_mon, ltp.tm_mday, ltp.tm_hour)
     fp = open(prefix+"psr-"+date+"-fft.csv", "a")
-    
+
     #
     # Write UTC header
     #
     fp.write("%02d:%02d:%02d," % (ltp.tm_hour, ltp.tm_min, ltp.tm_sec))
-    
+
     #
     # Spectrum is inverted:  Fc+bw/2 to Fc-bw/2
     #
@@ -388,7 +388,7 @@ def log_fft(freq,bw,prefix,fft):
 # We maintain a static tag dictionary for use later by the header
 #  update code
 #
-tag_dict = {} 
+tag_dict = {}
 first_tag = None
 def process_tag(tags):
     global first_tag
@@ -396,7 +396,7 @@ def process_tag(tags):
         tag_dict[pmt.to_python(tag.key)] = pmt.to_python(tag.value)
         if (first_tag == None):
             first_tag = time.time()
-    
+
 #
 # Used to find a tag in the tag_dict
 #
@@ -405,7 +405,7 @@ def get_tag(key):
         return (tag_dict[key])
     else:
         return None
-        
+
 didit = False
 #
 # Basically, near the end of the run, concatenates the correct header data
@@ -418,7 +418,7 @@ def update_header(pacer,runtime,smpsize):
     import shutil
     import os
     global smpwidth
-    
+
     if (smpwidth == 0):
         smpwidth = smpsize
 
@@ -440,11 +440,11 @@ def update_header(pacer,runtime,smpsize):
             endtime -= 0.5
     #
     # We're being called as an exit handler
-    # 
+    #
     else:
         endtime = time.time() - 30.0
         didit = False
-    
+
     #
     # This little dance ensures that we only update the header and concatenate
     #   the live sample data when:
@@ -453,7 +453,7 @@ def update_header(pacer,runtime,smpsize):
     #   o   We haven't already done this
     #
     if ((time.time() >= endtime) and didit == False):
-        
+
         #
         # We retrieve the previously-cached "rx_time" tag
         #
@@ -463,7 +463,7 @@ def update_header(pacer,runtime,smpsize):
         if (times != None):
             seconds = float(times[0])+float(times[1])
         else:
-            # 
+            #
             # This will result in a very-rough approximation
             #
             if (first_tag != None):
@@ -521,13 +521,13 @@ def get_swidth():
 #   with a "1.0", that filterbank bin will be included, else it won't.
 #
 def static_mask(freq,bw,fbsize,rfilist):
-    
+
     #
     # If no RFI list, the mask is all 1.0
     #
     if (rfilist == "" or len(rfilist) == 0 or rfilist == None):
         return ([1.0]*fbsize)
-    
+
     #
     # Step size is the bandwidth over the filterbank size
     #   (bin width, basically, in Hz)
@@ -535,7 +535,7 @@ def static_mask(freq,bw,fbsize,rfilist):
     step = bw/fbsize
     start = freq-(bw/2.0)
     end = freq+(bw/2.0)
-    
+
     #
     # Parse the RFI list, do a little sanity checking
     #  on the values.
@@ -575,23 +575,23 @@ def dynamic_mask(fft,smask,thresh):
     global deviation
     global automask
     global current_estimate
-   
-    
-    
+
+
+
     if (automask == None):
         automask = [1.0]*len(fft)
-    
+
     #
     # Our ultimate mask is based on both the user-input static mask
     #  and the dynamically-determined mask
     #
     smask = list(numpy.multiply(smask,automask))
-    
+
     #
     # How many blanked/excised channels in the static mask?
     #
     nzero = smask.count(0.0)
-    
+
     #
     # Determine trim range
     #
@@ -599,7 +599,7 @@ def dynamic_mask(fft,smask,thresh):
     ff = lf/10
     if (ff == 0):
         ff = 1
-    
+
     #
     # Calculate mean deviation, but only occasionally
     # Update automask, but only occasionally
@@ -610,7 +610,7 @@ def dynamic_mask(fft,smask,thresh):
         #
         trim_fft = fft[ff:-ff]
         trim_mask = list(smask[ff:-ff])
-        
+
         #
         # Compute a quick mean
         # Since the trim_fft bins at the trim_mask excision locations will
@@ -623,7 +623,7 @@ def dynamic_mask(fft,smask,thresh):
         mcount = len(trim_fft)-trim_mask.count(0.0)
         dmean = sum(numpy.multiply(trim_fft,trim_mask))
         dmean /= mcount
-        
+
         #
         # Now compute average deviation
         #
@@ -631,7 +631,7 @@ def dynamic_mask(fft,smask,thresh):
         for i in range(len(trim_fft)):
             if (trim_mask[i]):
                 adev += abs(trim_fft[i]-dmean)
-        
+
         #
         # Automask looks for FFT values that exceed the current
         #  mean estimate by a significant factor--a pulsar will
@@ -639,7 +639,7 @@ def dynamic_mask(fft,smask,thresh):
         #
         #
         for i in range(len(fft)):
-            
+
             #
             # Bigger than threshold? It goes on the automask
             #  AND NEVER LEAVES!  This prevents oscillation
@@ -647,11 +647,11 @@ def dynamic_mask(fft,smask,thresh):
             #
             if (fft[i] > (dmean*thresh)):
                 automask[i] = 0.0
-        
+
         #
         # Two-point smoothing on deviation
         #
-        if (deviation != 0.0):      
+        if (deviation != 0.0):
             deviation += adev/mcount
             deviation /= 2.0
         else:
@@ -669,7 +669,7 @@ def dynamic_mask(fft,smask,thresh):
     mean = mean[ff:-ff]
     lnm = len(mean)
     mean = sum(mean)
-    
+
     #
     # Then: divide by length - count of blanked channels
     #  (divide by count of non-masked channels, IOW)
@@ -680,7 +680,7 @@ def dynamic_mask(fft,smask,thresh):
     i = 0
     if False:
         for s in smask:
-            
+
             #
             # We apply the locally-estimated mean, and then dither by a
             #  small amount--this makes sure that the correlation of the
@@ -689,9 +689,9 @@ def dynamic_mask(fft,smask,thresh):
             if (s < 1.0):
                 mask[i] = random.uniform(mean-(deviation/2.0),mean+(deviation/2.0))
             i += 1
-    
+
     return(smask)
-    
+
 def invert_rfi_mask(mask):
     rmask = []
     for i in range(0,len(mask)):
@@ -699,11 +699,11 @@ def invert_rfi_mask(mask):
     return rmask
 
 estithen = time.time()
-frozen_estimate = 0.0   
+frozen_estimate = 0.0
 def get_current_estimate():
     global current_estimate
     global frozen_estimate
-    
+
     if (time.time() - estithen < 90):
         frozen_estimate = current_estimate
         return current_estimate
@@ -730,7 +730,7 @@ def get_correction(fbsize,correct,pacer):
     #
     if (correct == 0):
         return [1.0]*fbsize
-    
+
     #
     # If time to return a correction estimate
     #
@@ -738,31 +738,31 @@ def get_correction(fbsize,correct,pacer):
         # Compute correction if we haven't already done so
         if (correct_state == 0):
             correct_state = 1
-            
+
             #
             # Compute the fraction of the buffer we're ignoring
             #  for calculation of the average level
             #
             frac = int(fbsize/6)
-            
+
             #
             # Reduce smooth by fft_cnt
             #
             smooth_fft = numpy.divide(smooth_fft,fft_cnt)
             fft_cnt = 1
-            
+
             #
             # Produce the "window" over which we'll average
             #
             avg_window = smooth_fft[frac:-frac]
-            
+
             #
             # Average that "window"
             #
             avg = sum(avg_window)
             avg /= float(len(avg_window))
-            
-            
+
+
             #
             # Compute the ratio between the average and the smoothed FFT, and
             #  produce a scaling vector that makes them all roughly at the same level
@@ -781,7 +781,7 @@ def get_correction(fbsize,correct,pacer):
     #
     else:
         return [1.0]*fbsize
-    
+
 def get_sky_freq(sky,freq):
     return sky if sky != 0.0 else freq
 
@@ -795,7 +795,7 @@ def autoscale(scale,pace):
 current_channel = 0
 def get_current_channel(pacer,nchan):
     global current_channel
-    
+
     r = [0.0]*nchan
     r[current_channel] = 1.0
     current_channel += 1
@@ -813,17 +813,17 @@ def analyser(fft,nchan):
     global chcnts
     global spikes
     global lastchan
-    
+
     nfft = fft[0:len(fft)/2]
     if channels == None:
         channels = [numpy.array([0.0]*len(nfft))]*nchan
         chcnts = [0.0]*nchan
         spikes = [0]*nchan
-    
+
     ccn = current_channel
     channels[ccn] = numpy.add(nfft,channels[ccn])
     chcnts[ccn] += 1.0
-    
+
     #
     # Ignore if this is the first data after a channel change
     #
@@ -831,9 +831,9 @@ def analyser(fft,nchan):
         #print "New channel %d" % ccn
         lastchan = ccn
         return ccn
-    
+
     chavg = numpy.divide(channels[ccn], chcnts[ccn])
-    
+
     spike = 0
     winsize = 6
     if (chcnts[ccn] > 10):
@@ -842,7 +842,7 @@ def analyser(fft,nchan):
             window /= float(winsize)
             if (chavg[inspected] > window*3.5):
                 spike += 1
- 
+
         if (spike == 0):
             if (spikes[ccn] > 0):
                 spikes[ccn] -=1
@@ -854,4 +854,3 @@ def analyser(fft,nchan):
             automask[ccn] = 0.0
 
     return ccn
-

--- a/grc_parser.py
+++ b/grc_parser.py
@@ -62,7 +62,7 @@ fp = open(sys.argv[3], "r")
 lines = fp.readlines()
 for line in lines:
     line = line.replace("(", "(root, ", 1)
-    print line
+    print(line)
     eval(line)
 fp.close()
 

--- a/grc_parser.py
+++ b/grc_parser.py
@@ -31,7 +31,7 @@ def update_block(root, tag, name, subdict):
                 newval = subdict[ky.text]
                 val = param.find("value")
                 val.text = newval
-    
+
 def update_connection(root, source, sink, insub):
     for conn in root.iter("connection"):
         source_key = conn.find("source_block_id")

--- a/pulsar_filterbank.grc
+++ b/pulsar_filterbank.grc
@@ -3445,11 +3445,17 @@ def convert_sigproct(v):
     timestr="%02d%02d%02d.0" % (hours, minutes, seconds)
     return(float(timestr))
 
+
+def tobytes(s):
+    """converts specified parameter to bytes. Python 3 is much more picky regarding
+       differences between strings and bytes. This function is used in build_header_info()"""
+    return bytes(str(s),'utf-8')
+
 #
 # This will cause a header block to be prepended to the output file
 #
 # Thanks to Guillermo Gancio (ganciogm@gmail.com) for the inspiration
-#   and much of the code
+# and much of the code. Adjusted to python 3 by Tomek Mrugalski.
 #
 def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fbsize,rx_time,smpsize):
     global smpwidth
@@ -3465,7 +3471,6 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     header_args["bw"] = bw
     header_args["fbrate"] = fbrate
     header_args["fbsize"] = fbsize
-
 
     #
     # Time for one sample, in sec
@@ -3499,29 +3504,31 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     sub_bands=fbsize
 
     #
-    # Determine MJD from file timestamp
+    # Determine MJD from file timestamp. Open the output file as binary.
     #
     if (rx_time == None):
-        fp = open(outfile, "w")
+        fp = open(outfile, "wb")
         t_start = (os.path.getmtime(outfile) / 86400) + 40587
     else:
-        fp = open(outfile, "w")
+        fp = open(outfile, "wb")
         t_start = rx_time
 
     #
     # The rest here is mostly due to Guillermo Gancio ganciogm@gmail.com
     #
-    stx="HEADER_START"
-    etx="HEADER_END"
+    stx=tobytes("HEADER_START")
+    etx=tobytes("HEADER_END")
     fp.write(struct.pack('i', len(stx))+stx)
     fp.flush()
+
     #--
-    aux="rawdatafile"
+    aux=tobytes("rawdatafile")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
-    fp.write(struct.pack('i', len(outfile))+outfile)
+    fp.write(struct.pack('i', len(outfile))+tobytes(outfile))
+
     #--
-    aux="src_raj"
+    aux=tobytes("src_raj")
     aux=struct.pack('i', len(aux))+aux
     source_ra = convert_sigproct(source_ra)
     fp.write(aux)
@@ -3530,96 +3537,106 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     fp.flush()
 
     #--
-    aux="src_dej"
+    aux=tobytes("src_dej")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     source_dec= convert_sigproct(source_dec)
     aux=struct.pack('d', source_dec)
     fp.write(aux)
     #--
-    aux="az_start"
+
+    aux=tobytes("az_start")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', 0.0)
     fp.write(aux)
     #--
-    aux="za_start"
+    aux=tobytes("za_start")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', 0.0)
     fp.write(aux)
     #--
-    aux="tstart"
+    aux=tobytes("tstart")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', float(t_start))
     fp.write(aux)
     #--
-    aux="foff"
+    aux=tobytes("foff")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', f_off)
     fp.write(aux)
     #--
-    aux="fch1"
+    aux=tobytes("fch1")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', high_freq)
     fp.write(aux)
     #--
-    aux="nchans"
+    aux=tobytes("nchans")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', sub_bands)
     fp.write(aux)
     #--
-    aux="data_type"
+    aux=tobytes("data_type")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
     #--
-    aux="ibeam"
+
+
+    aux=tobytes("ibeam")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
     #--
-    aux="nbits"
+    aux=tobytes("nbits")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', smpsize*8)
     fp.write(aux)
     #--
-    aux="tsamp"
+
+
+    aux=tobytes("tsamp")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('d', tsamp)
     fp.write(aux)
     #--
-    aux="nbeams"
+    aux=tobytes("nbeams")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
+
+
     #--
-    aux="nifs"
+    aux=tobytes("nifs")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 1)
     fp.write(aux)
+
     #--
-    aux="source_name"
+    aux=tobytes("source_name")
     fp.write(struct.pack('i', len(aux))+aux)
-    fp.write(struct.pack('i', len(source_name))+source_name)
+    fp.write(struct.pack('i', len(source_name)) + tobytes(source_name))
+
+
     #--
-    aux="machine_id"
+    aux=tobytes("machine_id")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 20)
     fp.write(aux)
     #--
-    aux="telescope_id"
+    aux=tobytes("telescope_id")
     aux=struct.pack('i', len(aux))+aux
     fp.write(aux)
     aux=struct.pack('i', 20)
@@ -3933,8 +3950,10 @@ def dynamic_mask(fft,smask,thresh):
     #
     # Determine trim range
     #
+    # (Python 3 update: make sure the ff is integer. Arrays can only be
+    # indexed by integers)
     lf = len(fft)
-    ff = lf/10
+    ff = int(lf/10)
     if (ff == 0):
         ff = 1
 
@@ -4152,6 +4171,7 @@ def analyser(fft,nchan):
     global spikes
     global lastchan
 
+    # python 3 fix: indices must be integers
     nfft = fft[0:int(len(fft)/2)]
     if channels == None:
         channels = [numpy.array([0.0]*len(nfft))]*nchan

--- a/pulsar_filterbank.grc
+++ b/pulsar_filterbank.grc
@@ -1075,7 +1075,7 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
         )
         # if an attribute with the same name as a parameter is found,
         # a callback is registered (properties work, too).
-        
+
         self.set_output_multiple(fbsize)
         self.delaymap = [0]*fbsize
         delayincr = (smear/1000.0) * float(fbrate)
@@ -1084,17 +1084,17 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
         delayincr = int(delayincr)
         for i in range(fbsize):
             self.delaymap[(fbsize-i)-1] = i*delayincr
-        
+
         #
         # Needed in a few places
         #
         self.flen = fbsize
-        
+
         #
         # The pulsar period
         #
         self.p0 = period
-        
+
         #
         # The derived single-period pulse profile with various shifts
         #
@@ -1103,11 +1103,11 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
         self.shifts = []
         for p in ppmlist:
             self.shifts.append(float(p)*1.0e-6)
-            
+
         self.profiles = [[0.0]*tbins]*len(self.shifts)
         self.pcounts = [[0.0]*tbins]*len(self.shifts)
         self.nprofiles = len(self.profiles)
-        
+
         #
         #
         # How much time is in each bin?
@@ -1117,44 +1117,44 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
         self.tbint = []
         for shift in self.shifts:
             self.tbint.append((self.p0*(1.0+shift))/tbins)
-        
+
         #
         # The profile length
-        #   
+        #
         self.plen = tbins
-        
+
         #
         # Sample period
         #
         self.sper = 1.0/fbrate
-        
+
         #
         # Mission Elapsed Time
         # This is moved along at every time samples arrival--incremented
         #   by 'self.sper'
         #
         self.MET = 0.0
-        
+
         #
         # Open the output file
         #
         self.fname = filename
         self.sequence = 0
-        
+
         self.max_in = 0.0
         self.min_in = 100000000
-        
+
         #
         # The logging interval
         #
         self.INTERVAL = fbrate*interval
         self.logcount = self.INTERVAL
-        
+
         #print "tbin %-11.7f tbinp %-11.7f tbinn %-11.7f" % (self.tbin, self.tbinp, self.tbinn)
         fp = open(self.fname, "w")
         fp.write ("[\n")
         fp.close()
-        
+
     def work(self, input_items, output_items):
         """Do dedispersion/folding"""
         q = input_items[0]
@@ -1182,7 +1182,7 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
                         break
             else:
                 outval = sum(q[(i*self.flen):(i*self.flen)+self.flen])
-            
+
             #
             # Figure out where this sample goes in the profile buffer, based on MET
             # We place the next sample based on the MET, re-expressed in terms of
@@ -1195,17 +1195,17 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
                 where = int(where) % self.plen
                 self.profiles[x][where] += outval
                 self.pcounts[x][where] += 1
-            
+
             #
             # Increment Mission Elapsed Time
             #
             self.MET += self.sper
-            
+
             #
             # Decrement the log counter
             #
             self.logcount -= 1
-            
+
             #
             # If time to log, the output is the reduced-by-counts
             #  value of the profile.
@@ -1234,8 +1234,8 @@ class blk(gr.sync_block):  # other base classes are basic_block, decim_block, in
                 fp.write(json.dumps(d, indent=4, sort_keys=True)+",\n")
                 fp.close()
                 self.logcount = self.INTERVAL
-            
-            
+
+
         return len(q)
 </value>
     </param>
@@ -2674,7 +2674,7 @@ depends on the "wide" input parameter.</value>
     <param>
       <key>comment</key>
       <value>This effectively selects which channel we are
-currently observing for detected modulation 
+currently observing for detected modulation
 artifacts</value>
     </param>
     <param>
@@ -3375,30 +3375,30 @@ def dm_to_smear(freq,bw,dm):
 #
 # Convert DM to a reasonable number of FFT bins, given
 #  DM, center-frequency, bandwidth, and pw50
-# 
+#
 def dm_to_bins(dm,freq,bw,pw50):
-    
+
     #
     # Convert pw50 to milliseconds (sigh)
     #
     p50ms = pw50 * 1000.0
-    
+
     Dt = dm_to_smear(freq,bw,dm)
-    
+
     #
     # So that there's only 25% (of W50) residual smearing in each channel of the FB
     #
     required_bins = Dt/(p50ms/4.0)
-    
+
     #
     # We do a bit of base2 math to make this a nice FFT size
     #
     bins = math.log(required_bins)/math.log(2.0)
     if (abs(bins-int(bins)) &gt; 0.2):
         bins += 1
-    
+
     bins = int(bins)
-    
+
     #
     # No sense making the filterbank too small
     # Set bins so that minimum is 4 channels
@@ -3412,10 +3412,10 @@ def dm_to_bins(dm,freq,bw,pw50):
 #
 def write_header(fn, freq, bw, fbsize, fbrate, smpsize):
     global smpwidth
-    
+
     if (smpwidth == 0):
         smpwidth = smpsize
-        
+
     f = open(fn, "w")
     ltp = time.gmtime(time.time())
     f.write("frequency=%.5f\n" % freq)
@@ -3428,7 +3428,7 @@ def write_header(fn, freq, bw, fbsize, fbrate, smpsize):
         ltp.tm_min, ltp.tm_sec))
     f.write("Output sample size %d bytes\n" % smpsize)
     f.write("Expected disk write rate: %6.2f mbyte/sec\n" % ((fbsize*fbrate*smpsize)/1.0e6))
-    
+
 
 
 header_args = {}
@@ -3444,7 +3444,7 @@ def convert_sigproct(v):
     seconds = itime - (hours*3600) - (minutes*60)
     timestr="%02d%02d%02d.0" % (hours, minutes, seconds)
     return(float(timestr))
-  
+
 #
 # This will cause a header block to be prepended to the output file
 #
@@ -3453,7 +3453,7 @@ def convert_sigproct(v):
 #
 def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fbsize,rx_time,smpsize):
     global smpwidth
-    
+
     if (smpwidth == 0):
         smpwidth = smpsize
 
@@ -3471,33 +3471,33 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     # Time for one sample, in sec
     #
     tsamp=1.0/fbrate
-    
+
     #
     # Frequency offset between channels, in MHz
     #
     f_off=bw/fbsize
     f_off /= 1.0e6
     f_off *= -1
-    
+
     #
     # Highest frequency represented in FB, in MHz
     #
     high_freq = freq+(bw/2.0)
     high_freq  /= 1.0e6
     high_freq -= (f_off/2.0)
-    
+
     #
     # Lowest
     #
     low_freq = freq-(bw/2.0)
     low_freq /= 1.0e6
     low_freq += (f_off/2.0)
-    
+
     #
     # Number of subbands
     #
     sub_bands=fbsize
-    
+
     #
     # Determine MJD from file timestamp
     #
@@ -3507,7 +3507,7 @@ def build_header_info(outfile,source_name,source_ra,source_dec,freq,bw,fbrate,fb
     else:
         fp = open(outfile, "w")
         t_start = rx_time
- 
+
     #
     # The rest here is mostly due to Guillermo Gancio ganciogm@gmail.com
     #
@@ -3653,13 +3653,13 @@ def log_fft(freq,bw,prefix,fft):
     global smooth_fft
     global fft_cnt
     global last_smooth
-    
+
     #
     # Degenerate FFT length--sometimes on startup
     #
     if (len(fft) &lt; 2):
         return
-    
+
     #
     # Provide "smooth" FFT for get_correction
     #  function
@@ -3675,28 +3675,28 @@ def log_fft(freq,bw,prefix,fft):
     #
     if (time.time() &lt; next_fft):
         return
-    
+
     #
     # Schedule our next one
     #
     next_fft = time.time() + 10.0
- 
+
     #
     # Get current time, break out into "struct tm" style time fields
     #
     ltp = time.gmtime(time.time())
-    
+
     #
     # Constract filename from parts
     #
     date = "%04d%02d%02d%02d" % (ltp.tm_year, ltp.tm_mon, ltp.tm_mday, ltp.tm_hour)
     fp = open(prefix+"psr-"+date+"-fft.csv", "a")
-    
+
     #
     # Write UTC header
     #
     fp.write("%02d:%02d:%02d," % (ltp.tm_hour, ltp.tm_min, ltp.tm_sec))
-    
+
     #
     # Spectrum is inverted:  Fc+bw/2 to Fc-bw/2
     #
@@ -3726,7 +3726,7 @@ def log_fft(freq,bw,prefix,fft):
 # We maintain a static tag dictionary for use later by the header
 #  update code
 #
-tag_dict = {} 
+tag_dict = {}
 first_tag = None
 def process_tag(tags):
     global first_tag
@@ -3734,7 +3734,7 @@ def process_tag(tags):
         tag_dict[pmt.to_python(tag.key)] = pmt.to_python(tag.value)
         if (first_tag == None):
             first_tag = time.time()
-    
+
 #
 # Used to find a tag in the tag_dict
 #
@@ -3743,7 +3743,7 @@ def get_tag(key):
         return (tag_dict[key])
     else:
         return None
-        
+
 didit = False
 #
 # Basically, near the end of the run, concatenates the correct header data
@@ -3756,7 +3756,7 @@ def update_header(pacer,runtime,smpsize):
     import shutil
     import os
     global smpwidth
-    
+
     if (smpwidth == 0):
         smpwidth = smpsize
 
@@ -3778,11 +3778,11 @@ def update_header(pacer,runtime,smpsize):
             endtime -= 0.5
     #
     # We're being called as an exit handler
-    # 
+    #
     else:
         endtime = time.time() - 30.0
         didit = False
-    
+
     #
     # This little dance ensures that we only update the header and concatenate
     #   the live sample data when:
@@ -3791,7 +3791,7 @@ def update_header(pacer,runtime,smpsize):
     #   o   We haven't already done this
     #
     if ((time.time() &gt;= endtime) and didit == False):
-        
+
         #
         # We retrieve the previously-cached "rx_time" tag
         #
@@ -3801,7 +3801,7 @@ def update_header(pacer,runtime,smpsize):
         if (times != None):
             seconds = float(times[0])+float(times[1])
         else:
-            # 
+            #
             # This will result in a very-rough approximation
             #
             if (first_tag != None):
@@ -3859,13 +3859,13 @@ def get_swidth():
 #   with a "1.0", that filterbank bin will be included, else it won't.
 #
 def static_mask(freq,bw,fbsize,rfilist):
-    
+
     #
     # If no RFI list, the mask is all 1.0
     #
     if (rfilist == "" or len(rfilist) == 0 or rfilist == None):
         return ([1.0]*fbsize)
-    
+
     #
     # Step size is the bandwidth over the filterbank size
     #   (bin width, basically, in Hz)
@@ -3873,7 +3873,7 @@ def static_mask(freq,bw,fbsize,rfilist):
     step = bw/fbsize
     start = freq-(bw/2.0)
     end = freq+(bw/2.0)
-    
+
     #
     # Parse the RFI list, do a little sanity checking
     #  on the values.
@@ -3913,23 +3913,23 @@ def dynamic_mask(fft,smask,thresh):
     global deviation
     global automask
     global current_estimate
-   
-    
-    
+
+
+
     if (automask == None):
         automask = [1.0]*len(fft)
-    
+
     #
     # Our ultimate mask is based on both the user-input static mask
     #  and the dynamically-determined mask
     #
     smask = list(numpy.multiply(smask,automask))
-    
+
     #
     # How many blanked/excised channels in the static mask?
     #
     nzero = smask.count(0.0)
-    
+
     #
     # Determine trim range
     #
@@ -3937,7 +3937,7 @@ def dynamic_mask(fft,smask,thresh):
     ff = lf/10
     if (ff == 0):
         ff = 1
-    
+
     #
     # Calculate mean deviation, but only occasionally
     # Update automask, but only occasionally
@@ -3948,7 +3948,7 @@ def dynamic_mask(fft,smask,thresh):
         #
         trim_fft = fft[ff:-ff]
         trim_mask = list(smask[ff:-ff])
-        
+
         #
         # Compute a quick mean
         # Since the trim_fft bins at the trim_mask excision locations will
@@ -3961,7 +3961,7 @@ def dynamic_mask(fft,smask,thresh):
         mcount = len(trim_fft)-trim_mask.count(0.0)
         dmean = sum(numpy.multiply(trim_fft,trim_mask))
         dmean /= mcount
-        
+
         #
         # Now compute average deviation
         #
@@ -3969,7 +3969,7 @@ def dynamic_mask(fft,smask,thresh):
         for i in range(len(trim_fft)):
             if (trim_mask[i]):
                 adev += abs(trim_fft[i]-dmean)
-        
+
         #
         # Automask looks for FFT values that exceed the current
         #  mean estimate by a significant factor--a pulsar will
@@ -3977,7 +3977,7 @@ def dynamic_mask(fft,smask,thresh):
         #
         #
         for i in range(len(fft)):
-            
+
             #
             # Bigger than threshold? It goes on the automask
             #  AND NEVER LEAVES!  This prevents oscillation
@@ -3985,11 +3985,11 @@ def dynamic_mask(fft,smask,thresh):
             #
             if (fft[i] &gt; (dmean*thresh)):
                 automask[i] = 0.0
-        
+
         #
         # Two-point smoothing on deviation
         #
-        if (deviation != 0.0):      
+        if (deviation != 0.0):
             deviation += adev/mcount
             deviation /= 2.0
         else:
@@ -4007,7 +4007,7 @@ def dynamic_mask(fft,smask,thresh):
     mean = mean[ff:-ff]
     lnm = len(mean)
     mean = sum(mean)
-    
+
     #
     # Then: divide by length - count of blanked channels
     #  (divide by count of non-masked channels, IOW)
@@ -4018,7 +4018,7 @@ def dynamic_mask(fft,smask,thresh):
     i = 0
     if False:
         for s in smask:
-            
+
             #
             # We apply the locally-estimated mean, and then dither by a
             #  small amount--this makes sure that the correlation of the
@@ -4027,9 +4027,9 @@ def dynamic_mask(fft,smask,thresh):
             if (s &lt; 1.0):
                 mask[i] = random.uniform(mean-(deviation/2.0),mean+(deviation/2.0))
             i += 1
-    
+
     return(smask)
-    
+
 def invert_rfi_mask(mask):
     rmask = []
     for i in range(0,len(mask)):
@@ -4037,11 +4037,11 @@ def invert_rfi_mask(mask):
     return rmask
 
 estithen = time.time()
-frozen_estimate = 0.0   
+frozen_estimate = 0.0
 def get_current_estimate():
     global current_estimate
     global frozen_estimate
-    
+
     if (time.time() - estithen &lt; 90):
         frozen_estimate = current_estimate
         return current_estimate
@@ -4068,7 +4068,7 @@ def get_correction(fbsize,correct,pacer):
     #
     if (correct == 0):
         return [1.0]*fbsize
-    
+
     #
     # If time to return a correction estimate
     #
@@ -4076,31 +4076,31 @@ def get_correction(fbsize,correct,pacer):
         # Compute correction if we haven't already done so
         if (correct_state == 0):
             correct_state = 1
-            
+
             #
             # Compute the fraction of the buffer we're ignoring
             #  for calculation of the average level
             #
             frac = int(fbsize/6)
-            
+
             #
             # Reduce smooth by fft_cnt
             #
             smooth_fft = numpy.divide(smooth_fft,fft_cnt)
             fft_cnt = 1
-            
+
             #
             # Produce the "window" over which we'll average
             #
             avg_window = smooth_fft[frac:-frac]
-            
+
             #
             # Average that "window"
             #
             avg = sum(avg_window)
             avg /= float(len(avg_window))
-            
-            
+
+
             #
             # Compute the ratio between the average and the smoothed FFT, and
             #  produce a scaling vector that makes them all roughly at the same level
@@ -4119,7 +4119,7 @@ def get_correction(fbsize,correct,pacer):
     #
     else:
         return [1.0]*fbsize
-    
+
 def get_sky_freq(sky,freq):
     return sky if sky != 0.0 else freq
 
@@ -4133,7 +4133,7 @@ def autoscale(scale,pace):
 current_channel = 0
 def get_current_channel(pacer,nchan):
     global current_channel
-    
+
     r = [0.0]*nchan
     r[current_channel] = 1.0
     current_channel += 1
@@ -4151,17 +4151,17 @@ def analyser(fft,nchan):
     global chcnts
     global spikes
     global lastchan
-    
+
     nfft = fft[0:len(fft)/2]
     if channels == None:
         channels = [numpy.array([0.0]*len(nfft))]*nchan
         chcnts = [0.0]*nchan
         spikes = [0]*nchan
-    
+
     ccn = current_channel
     channels[ccn] = numpy.add(nfft,channels[ccn])
     chcnts[ccn] += 1.0
-    
+
     #
     # Ignore if this is the first data after a channel change
     #
@@ -4169,9 +4169,9 @@ def analyser(fft,nchan):
         #print "New channel %d" % ccn
         lastchan = ccn
         return ccn
-    
+
     chavg = numpy.divide(channels[ccn], chcnts[ccn])
-    
+
     spike = 0
     winsize = 6
     if (chcnts[ccn] &gt; 10):
@@ -4180,7 +4180,7 @@ def analyser(fft,nchan):
             window /= float(winsize)
             if (chavg[inspected] &gt; window*3.5):
                 spike += 1
- 
+
         if (spike == 0):
             if (spikes[ccn] &gt; 0):
                 spikes[ccn] -=1

--- a/pulsar_filterbank.grc
+++ b/pulsar_filterbank.grc
@@ -3808,8 +3808,8 @@ def update_header(pacer,runtime,smpsize):
                 seconds = first_tag
             else:
                 seconds = time.time()
-            print "No rx_time tag, start time will be approximate."
-        
+            print("No rx_time tag, start time will be approximate.")
+
         #
         # Turn real seconds into MJD
         #

--- a/pulsar_filterbank.grc
+++ b/pulsar_filterbank.grc
@@ -4152,7 +4152,7 @@ def analyser(fft,nchan):
     global spikes
     global lastchan
 
-    nfft = fft[0:len(fft)/2]
+    nfft = fft[0:int(len(fft)/2)]
     if channels == None:
         channels = [numpy.array([0.0]*len(nfft))]*nchan
         chcnts = [0.0]*nchan

--- a/pulsar_filterbank.grc
+++ b/pulsar_filterbank.grc
@@ -3231,7 +3231,7 @@ samples</value>
     </param>
     <param>
       <key>value</key>
-      <value>airspy=0</value>
+      <value>"airspy=0"</value>
     </param>
   </block>
   <block>


### PR DESCRIPTION
Hi!

I've tried to compile your code on modern system (Ubuntu 21.04, with GNU Radio 3.9.2.0 and Python 3.9.5) and got many errors. I managed to fix them. I haven't tested the changes yet, but at least there's a compiled version to play with.

This PR fixes the following errors:

1. **makefile bug**: 

```
grcc -d . pulsar_filterbank_uhd.grc
usage: grcc [-h] [-o DIR] [-u] [-r] GRC_FILE [GRC_FILE ...]
grcc: error: unrecognized arguments: -d
```

2. **print syntax (python 3)**:
```
  File "<string>", line 473
    print "No rx_time tag, start time will be approximate."
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("No rx_time tag, start time will be approximate.")?
```

3. **Invalid syntax**:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/gnuradio/grc/core/FlowGraph.py", line 258, in renew_namespace
    value = eval(parameter_block.params['value'].to_code(), namespace)
  File "<string>", line 1
    airspy=0
          ^
SyntaxError: invalid syntax
```
4. **couple other errors**, mostly related to attempts to index with non-integers:
```
9 errors from flowgraph:
Param - Value(value):
	Value "fb_helper.analyser(analysis_poll_fast,fbsize)" cannot be evaluated:
	slice indices must be integers or None or have an __index__ methodParam - Value(value):
	Value "fb_helper.build_header_info(pfname+".fil",source,ra,dec,fb_helper.get_sky_freq(sky,freq),srate,fbrate,fbsize,None,swidth)" cannot be evaluated:
	can't concat str to bytesParam - Value(value):
	Value "fb_helper.dynamic_mask(fft_poll,rfi_mask,thresh)" cannot be evaluated:
	slice indices must be integers or None or have an __index__ methodBlock - blocks_multiply_const_vxx_0 - Multiply Const(blocks_multiply_const_vxx):
	Assertion "(vlen > 1 and len(const) == vlen) or (vlen == 1)" did not evaluate.Param - Constant(const):
	Value "numpy.multiply(rfi_mask2,shaper)" cannot be evaluated:
	unsupported operand type(s) for *: 'NoneType' and 'float'Param - Constant(const):
	Expression None is invalid for type'real_vector'.Block - blocks_multiply_const_vxx_2 - Multiply Const(blocks_multiply_const_vxx):
	Assertion "(vlen > 1 and len(const) == vlen) or (vlen == 1)" did not evaluate.Param - Constant(const):
	Value "fb_helper.invert_rfi_mask(rfi_mask2)*numpy.array([magn]*fbsize)" cannot be evaluated:
	object of type 'NoneType' has no len()Param - Constant(const):
	Expression None is invalid for type'real_vector'.
```

My editor also fixed some whitespace problems.

Each fix is a separate commit. Feel free to cherry-pick as you see fit. Also, I'm eager to tweak this patch in whatever direction you see appropriate.

Thanks for sharing this software!